### PR TITLE
remove extra encode call

### DIFF
--- a/reap/api/admin.py
+++ b/reap/api/admin.py
@@ -219,7 +219,7 @@ class Client:
     '''A client in the Harvest system.'''
     def __init__(self, hv, json):
         self.hv = hv
-        self.name = json['name'].encode('utf-8')
+        self.name = json['name']
         self.id = json['id']
         self.created = parse_time(json['created_at'])
         self.updated = parse_time(json['updated_at'])
@@ -228,7 +228,7 @@ class Client:
         self.currency = json['currency']
         self.currency_symbol = json['currency_symbol']
         self.active = json['active']
-        self.details = json['details'].encode('utf-8')
+        self.details = json['details']
         timeframes = json['default_invoice_timeframe']
         if timeframes and timeframes != 'Custom':
             pst = lambda timestr: \


### PR DESCRIPTION
should close #5.

Don't know why I had those `.encode()` calls there. It shouldn't be needed. Unfortunately, I don't have a way to test this quickly.
